### PR TITLE
Fix load testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Install ioredis with `bun install ioredis`.
 export the redis password as an env variable
 `export REDIS_PASSWORD=<your_password>` so that it can be read by `stats.ts`.
 
-Run with: `cd load_testing/ && k6 run mint.js`.
+Run with: `cd load_testing/ && k6 run --vus <number of virtual users> --duration <time in seconds> mint.js`.
+
+For example vus = 2 and duration = 30s
 
 At the end of the test runs, a new `summary.html` file will be generated that contains the results of k6.
 

--- a/load_testing/mint.js
+++ b/load_testing/mint.js
@@ -4,10 +4,6 @@ import { htmlReport } from "https://raw.githubusercontent.com/benc-uk/k6-reporte
 
 const responseTimeTrend = new Trend("response_time");
 
-export const options = {
-  iterations: 50000,
-};
-
 export function handleSummary(data) {
   console.log(
     `Average response time: ${data.metrics["response_time"].values["p(95)"]} ms`,

--- a/load_testing/rps.lua
+++ b/load_testing/rps.lua
@@ -55,7 +55,7 @@ if total_requests > 0 then
 
     local requests_per_second = total_requests / time_span_sec
 
-    return { requests_per_second }
+    return { requests_per_second, total_requests }
 else
     return { 0 }
 end

--- a/load_testing/stats.ts
+++ b/load_testing/stats.ts
@@ -17,10 +17,14 @@ async function calculateAverages() {
     const rpsResult: any = await redis.eval(rpsScript, 0);
     const avgFinishedTime = avgResult;
     const medianResponseTime = medianResult;
-    const rps = rpsResult;
+    const rps = rpsResult[0];
+    const totalRequests = rpsResult[1];
     console.log(`Average Finished Time: ${avgFinishedTime} ms`);
-    console.log(`Median Response Time: ${medianResponseTime} ms`);
-    console.log(`Rquests Per Second: ${rps}`);
+    console.log(
+      `Median Queue Wait Time for Request Processing: ${medianResponseTime} ms`,
+    );
+    console.log(`Requests Per Second: ${rps}`);
+    console.log(`Requests: ${totalRequests}`);
   } catch (error) {
     console.error("Error running Lua script:", error);
   }


### PR DESCRIPTION
It is more meaningful to not predetermine the number of the request but the number of users performing the requests, in a specific duration. 

E.g.
when running `k6 run --vus 10 --duration 30s  mint.js`
and the results are:

`
Average Finished Time: 1543742 ms

Median Response Time: 1523729 ms

Requests Per Second: 24226

Requests: 726831
`

.env 
`
MODULE_NAME=contract_example

JOB_RETRIES=3

JOB_RETRY_DELAY=1000

BUFFER_SIZE=500

STALE_BUFFER_TIMEOUT_MS=3000

PTE_COIN_BATCH_SIZE=20

PTE_INITIAL_COIN_BALANCE=5000000000

PTE_MINIMUM_COIN_BALANCE=5000000000

PTE_MAX_POOL_SIZE=5

NETWORK=testnet

BULLMQ_WORKER_CONCURRENCY=10
`